### PR TITLE
Add basic Nuxt landing page and API route

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtPage />
+</template>

--- a/assets/main.css
+++ b/assets/main.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/components/Gallery.vue
+++ b/components/Gallery.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+    <img
+      v-for="foto in fotos"
+      :key="foto"
+      :src="foto"
+      loading="lazy"
+      class="rounded shadow-lg transform hover:scale-105 transition-transform duration-300"
+      alt="galerijfoto"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ type: string }>();
+
+const { data } = await useFetch<{ fotos: string[] }>(`/api/fotos?type=${props.type}`);
+const fotos = data.value?.fotos || [];
+</script>

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <header class="sticky top-0 z-50 bg-dark text-copper">
+      <nav class="container mx-auto flex items-center justify-between py-4 px-4">
+        <div class="flex items-center space-x-2">
+          <img src="/logo.png" alt="Logo" class="h-10" />
+          <span class="font-bold text-2xl">BBQ &amp; Sound</span>
+        </div>
+        <ul class="hidden md:flex space-x-6">
+          <li><a href="#catering" class="hover:text-copper-dark">BBQ Catering</a></li>
+          <li><a href="#verhuur" class="hover:text-copper-dark">Licht &amp; Geluid</a></li>
+          <li><a href="#offerte" class="hover:text-copper-dark">Offerte</a></li>
+        </ul>
+        <a href="#offerte" class="hidden md:block bg-copper text-dark px-4 py-2 rounded hover:bg-copper-dark">Vraag offerte aan</a>
+      </nav>
+    </header>
+
+    <section class="relative h-screen flex items-center justify-center bg-cover bg-center" :style="{ backgroundImage: 'url(/hero.jpg)' }">
+      <div class="absolute inset-0 bg-black/60"></div>
+      <div class="relative z-10 text-center text-white px-4">
+        <h1 class="text-5xl md:text-6xl font-bold mb-4">Sizzling BBQ &amp; Events</h1>
+        <p class="text-xl md:text-2xl mb-6">Amerikaanse catering &amp; verhuur in vintage stijl</p>
+        <a href="#offerte" class="bg-copper text-dark px-6 py-3 rounded hover:bg-copper-dark">Offerte aanvragen</a>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+// geen extra script nodig
+</script>

--- a/components/OfferForm.vue
+++ b/components/OfferForm.vue
@@ -1,0 +1,54 @@
+<template>
+  <form class="space-y-4 max-w-xl mx-auto" @submit.prevent="submitForm">
+    <div>
+      <label for="naam" class="block font-semibold mb-1">Naam</label>
+      <input v-model="form.naam" id="naam" type="text" class="w-full px-3 py-2 rounded bg-steel text-white" required />
+    </div>
+    <div>
+      <label for="email" class="block font-semibold mb-1">E-mail</label>
+      <input v-model="form.email" id="email" type="email" class="w-full px-3 py-2 rounded bg-steel text-white" required />
+    </div>
+    <div>
+      <label for="datum" class="block font-semibold mb-1">Datum</label>
+      <input v-model="form.datum" id="datum" type="date" class="w-full px-3 py-2 rounded bg-steel text-white" required />
+    </div>
+    <div>
+      <label for="personen" class="block font-semibold mb-1">Aantal personen</label>
+      <input v-model="form.personen" id="personen" type="number" min="1" class="w-full px-3 py-2 rounded bg-steel text-white" required />
+    </div>
+    <div>
+      <label for="feest" class="block font-semibold mb-1">Type feest</label>
+      <select v-model="form.feest" id="feest" class="w-full px-3 py-2 rounded bg-steel text-white" required>
+        <option value="bedrijfsfeest">Bedrijfsfeest</option>
+        <option value="verjaardag">Verjaardag</option>
+        <option value="bruiloft">Bruiloft</option>
+      </select>
+    </div>
+    <div>
+      <label for="pakket" class="block font-semibold mb-1">Verhuurpakket</label>
+      <select v-model="form.pakket" id="pakket" class="w-full px-3 py-2 rounded bg-steel text-white" required>
+        <option value="basis">Basis</option>
+        <option value="deluxe">Deluxe</option>
+        <option value="pro">Pro</option>
+      </select>
+    </div>
+    <button type="submit" class="bg-copper text-dark px-4 py-2 rounded hover:bg-copper-dark">Verstuur</button>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const form = ref({
+  naam: '',
+  email: '',
+  datum: '',
+  personen: '',
+  feest: '',
+  pakket: ''
+})
+
+function submitForm() {
+  alert(JSON.stringify(form.value))
+}
+</script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,0 +1,6 @@
+import { defineNuxtConfig } from 'nuxt'
+
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/tailwindcss'],
+  css: ['@/assets/main.css'],
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "catering-hop-bites",
+  "private": true,
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "start": "nuxt start"
+  },
+  "dependencies": {
+    "nuxt": "latest",
+    "@nuxtjs/tailwindcss": "latest"
+  }
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="font-sans bg-dark text-copper">
+    <Hero />
+
+    <section id="catering" class="py-16 bg-dark text-copper">
+      <div class="container mx-auto px-4">
+        <h2 class="text-4xl font-bold mb-4">BBQ Catering</h2>
+        <p class="mb-6">Heerlijke slow-cooked BBQ gerechten en Amerikaanse classics voor ieder feestje.</p>
+        <Gallery type="catering" />
+      </div>
+    </section>
+
+    <section id="verhuur" class="py-16 bg-steel text-copper">
+      <div class="container mx-auto px-4">
+        <h2 class="text-4xl font-bold mb-4">Licht &amp; Geluid Verhuur</h2>
+        <p class="mb-6">Compleet verhuurpakket van microfoons tot DJ-set en showverlichting.</p>
+        <Gallery type="verhuur" />
+      </div>
+    </section>
+
+    <section id="offerte" class="py-16 bg-dark text-copper">
+      <div class="container mx-auto px-4">
+        <h2 class="text-4xl font-bold mb-4">Offerte aanvragen</h2>
+        <OfferForm />
+      </div>
+    </section>
+
+    <footer class="py-8 bg-steel text-center text-copper">
+      &copy; {{ new Date().getFullYear() }} BBQ &amp; Sound. Alle rechten voorbehouden.
+    </footer>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Geen extra logica nodig
+</script>

--- a/server/api/fotos.ts
+++ b/server/api/fotos.ts
@@ -1,0 +1,30 @@
+import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+
+export default defineEventHandler(async (event) => {
+  const type = getQuery(event).type as string || 'catering'
+
+  const client = new S3Client({
+    endpoint: process.env.MINIO_ENDPOINT || 'http://localhost:9000',
+    region: 'us-east-1',
+    credentials: {
+      accessKeyId: process.env.MINIO_ACCESS_KEY || 'minioadmin',
+      secretAccessKey: process.env.MINIO_SECRET_KEY || 'minioadmin'
+    },
+    forcePathStyle: true
+  })
+
+  const bucket = process.env.MINIO_BUCKET || 'catering-fotos'
+
+  // In werkelijkheid zouden we de object keys uit de bucket halen
+  const filenames = ['foto1.jpg', 'foto2.jpg', 'foto3.jpg']
+
+  const fotos = await Promise.all(
+    filenames.map(async (name) => {
+      const command = new GetObjectCommand({ Bucket: bucket, Key: `${type}/${name}` })
+      return getSignedUrl(client, command, { expiresIn: 60 * 60 })
+    })
+  )
+
+  return { fotos }
+})

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './components/**/*.{vue,js,ts}',
+    './pages/**/*.{vue,js,ts}',
+    './app.vue'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        dark: '#0f0f0f',
+        steel: '#2c2c2c',
+        copper: '#b87333',
+        'copper-dark': '#965a2e'
+      },
+      fontFamily: {
+        sans: ['\"Bebas Neue\"', 'sans-serif']
+      }
+    }
+  },
+  plugins: []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}


### PR DESCRIPTION
## Summary
- add landing page with hero, gallery and offer form
- create Hero, Gallery and OfferForm components
- define industrial themed Tailwind CSS config
- add mock MinIO photo API

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c049349bc832798720654fd5bd856